### PR TITLE
skip tokenizing html

### DIFF
--- a/src/api/anthropic.ts
+++ b/src/api/anthropic.ts
@@ -40,7 +40,7 @@ const tools = [
 export const askClaude = async(
   messages: Message[], html?: string, css?: string, js?: string,
 ): Promise<(Text | ToolUse)[]> => {
-  const systemPrompt = `${base_prompt} HTML: ${tokenize(html || '')}, CSS: ${tokenize(css || '')}, JS: ${tokenize(js || '')}`
+  const systemPrompt = `${base_prompt} HTML: ${html}, CSS: ${tokenize(css || '')}, JS: ${tokenize(js || '')}`
 
   const reply = await makeAnthropicRequest<AnthropicResponse>({
     model: 'claude-3-5-sonnet-20240620',


### PR DESCRIPTION
As a fix for #11, this PR skips tokenizing the HTML altogether. The token count would increase, but it seems to work for now.